### PR TITLE
Support custom Sentry logger value

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Add the following to an initializer:
 ```ruby
 require 'resque-sentry'
 
+# [optional] custom logger value to use when sending to Sentry (default is 'root')
+Resque::Failure::Sentry.logger = "resque"
+
 Resque::Failure::Multiple.classes = [Resque::Failure::Redis, Resque::Failure::Sentry]
 Resque::Failure.backend = Resque::Failure::Multiple
 ```

--- a/lib/resque/failure/sentry.rb
+++ b/lib/resque/failure/sentry.rb
@@ -17,14 +17,12 @@ module Resque
     #
     class Sentry < Base
 
-      @@logger = nil
-
       def self.logger
-        @@logger
+        @logger
       end
 
       def self.logger=(value)
-        @@logger = value
+        @logger = value
       end
 
       def save

--- a/lib/resque/failure/sentry.rb
+++ b/lib/resque/failure/sentry.rb
@@ -16,8 +16,21 @@ module Resque
     #   Resque::Failure.backend = Resque::Failure::Multiple
     #
     class Sentry < Base
+
+      @@logger = nil
+
+      def self.logger
+        @@logger
+      end
+
+      def self.logger=(value)
+        @@logger = value
+      end
+
       def save
-        Raven.capture_exception(exception)
+        options = {}
+        options[:logger] = self.class.logger if self.class.logger
+        Raven.capture_exception(exception, options)
       end
 
       def self.count

--- a/resque-sentry.gemspec
+++ b/resque-sentry.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/gocardless/resque-sentry'
 
   gem.add_dependency 'resque', '>= 1.18.0'
-  gem.add_dependency 'sentry-raven', '~> 0.4.6'
+  gem.add_dependency 'sentry-raven', '>= 0.4.6'
   gem.add_development_dependency 'rspec', '~> 2.6'
   gem.add_development_dependency 'mocha', '~> 0.11.0'
 

--- a/spec/sentry_spec.rb
+++ b/spec/sentry_spec.rb
@@ -2,14 +2,28 @@ require 'spec_helper'
 
 describe Resque::Failure::Sentry do
   it "sends errors to Sentry" do
+    sentry_options = {}
     exception = StandardError.new("Test Error")
     worker = Resque::Worker.new(:test)
     queue = "test"
     payload = {'class' => Object, 'args' => 1}
 
     event = mock
-    Raven.expects(:capture_exception).with(exception)
+    Raven.expects(:capture_exception).with(exception, sentry_options)
 
+    backend = Resque::Failure::Sentry.new(exception, worker, queue, payload)
+    backend.save
+  end
+
+  it "will use the configured Sentry logger" do
+    Resque::Failure::Sentry.logger = "resque"
+    sentry_options = { :logger => "resque" }
+    exception = StandardError.new("Test Error")
+    worker = Resque::Worker.new(:test)
+    queue = "test"
+    payload = {'class' => Object, 'args' => 1}
+
+    Raven.expects(:capture_exception).with(exception, sentry_options)
     backend = Resque::Failure::Sentry.new(exception, worker, queue, payload)
     backend.save
   end


### PR DESCRIPTION
This pull request adds `Resque::Failure::Sentry.logger` which can be used to set a custom logger value for Resque errors in Sentry. Then, in the Sentry UI, users can filter to see only Resque errors. This is completely opt-in, no logger value will be sent by default - only if  `Resque::Failure::Sentry.logger` has been set.

In addition, the gem dependency for 'sentry-raven' was changed to ">= 0.4.6" so that this gem can be used with the latest release.

Closes gocardless/resque-sentry#1
