### PR TITLE
Send class and arguments in context

### DIFF
--- a/lib/resque/failure/sentry.rb
+++ b/lib/resque/failure/sentry.rb
@@ -28,6 +28,10 @@ module Resque
       def save
         options = {}
         options[:logger] = self.class.logger if self.class.logger
+        options[:extra] = {
+          "Object" => payload['class'],
+          "Arguments" => payload['args']
+        }
         Raven.capture_exception(exception, options)
       end
 

--- a/spec/sentry_spec.rb
+++ b/spec/sentry_spec.rb
@@ -2,11 +2,16 @@ require 'spec_helper'
 
 describe Resque::Failure::Sentry do
   it "sends errors to Sentry" do
-    sentry_options = {}
+    sentry_options = { 
+      :extra => { 
+        "Object" => Object,
+        "Arguments" => [ 1, "foo" ]
+      } 
+    }
     exception = StandardError.new("Test Error")
     worker = Resque::Worker.new(:test)
     queue = "test"
-    payload = {'class' => Object, 'args' => 1}
+    payload = {'class' => Object, 'args' => [ 1, "foo" ]}
 
     event = mock
     Raven.expects(:capture_exception).with(exception, sentry_options)
@@ -17,11 +22,17 @@ describe Resque::Failure::Sentry do
 
   it "will use the configured Sentry logger" do
     Resque::Failure::Sentry.logger = "resque"
-    sentry_options = { :logger => "resque" }
+    sentry_options = { 
+      :logger => "resque",
+      :extra => { 
+        "Object" => Object,
+        "Arguments" => [ 1, "foo" ]
+      } 
+    }
     exception = StandardError.new("Test Error")
     worker = Resque::Worker.new(:test)
     queue = "test"
-    payload = {'class' => Object, 'args' => 1}
+    payload = {'class' => Object, 'args' => [ 1, "foo" ]}
 
     Raven.expects(:capture_exception).with(exception, sentry_options)
     backend = Resque::Failure::Sentry.new(exception, worker, queue, payload)


### PR DESCRIPTION
To aid in debugging I've added the object and arguments to the information sent to Sentry so that it can be seen while looking at the report, instead of having to go and dig it out from the failed queue in Resque.
